### PR TITLE
safe handling of Numbers

### DIFF
--- a/lib/delve-connection.js
+++ b/lib/delve-connection.js
@@ -120,7 +120,7 @@ export default class DelveConnection {
 const regexVariable = /\${(.*?)}/g
 
 function replaceVariable (value, variables) {
-  return value.replace(regexVariable, (group, name) => {
+  return String(value).replace(regexVariable, (group, name) => {
     if (name.startsWith('env.')) {
       return variables.env[name.replace('env.', '')]
     }


### PR DESCRIPTION
When value for a key in environment variable is a number, code breaks with a cryptic error to a user.
The error says: "value.replace()" does not exist.

My fix is making sure values are always strings.